### PR TITLE
fix: Allow NuvlaEdge-Go to clean previous status notes

### DIFF
--- a/nuvlaedge/common/resources/nuvlaEdgeStatus.go
+++ b/nuvlaedge/common/resources/nuvlaEdgeStatus.go
@@ -32,7 +32,7 @@ type NuvlaEdgeStatus struct {
 
 	// NuvlaEdge report
 	Status      string   `json:"status,omitempty"`
-	StatusNotes []string `json:"status-notes,omitempty"`
+	StatusNotes []string `json:"status-notes"`
 
 	// Telemetry
 	Network   map[string]any `json:"network,omitempty"`

--- a/nuvlaedge/monitoring/metricsMonitor.go
+++ b/nuvlaedge/monitoring/metricsMonitor.go
@@ -357,6 +357,7 @@ func (t *MetricsMonitor) UpdaterStatus(errChan chan<- error) {
 }
 
 func (t *MetricsMonitor) UpdaterStatusNotes(errChan chan<- error) {
+	t.nuvlaEdgeStatus.StatusNotes = []string{}
 	errChan <- nil
 }
 


### PR DESCRIPTION
Closes sixsq/tasklist#3214